### PR TITLE
Add functionality to either download latest or specific release of Directus

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -16,6 +16,12 @@ get_directus() {
 
     if [ -n "$PROJECT_VERS" ]; then
       DOWNLOAD_CMD="${DOWNLOAD_CMD}/${PROJECT_VERS}"
+    else
+      LATEST_VERS=$(curl -s https://api.github.com/repos/${PROJECT_NAME}/${PROJECT_NAME}/releases/latest |
+        grep 'tag_name' |
+        cut -d '"' -f4
+        )
+      DOWNLOAD_CMD="${DOWNLOAD_CMD}/${LATEST_VERS}"
     fi
 
     # Don't double quote as it needs to execute the command stored within
@@ -31,9 +37,9 @@ get_directus() {
 
 install_directus() {
   DIRECTUS_CLI="${PROJECT_DIR}/bin/directus"
-  php "$DIRECTUS_CLI" install:config -h localhost -u root -p 123 -n directus
-  php "$DIRECTUS_CLI" install:database
-  php "$DIRECTUS_CLI" install:install -e admin@getdirectus.com -p password -t "Directus Demo"
+  php $DIRECTUS_CLI install:config -h localhost -u root -p 123 -n directus
+  php $DIRECTUS_CLI install:database
+  php $DIRECTUS_CLI install:install -e admin@getdirectus.com -p password -t "Directus Demo"
 }
 
 apt-get update

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,28 +1,39 @@
 #!/usr/bin/env bash
 
 # Directus installation path
-DIR=/var/www/html
+DIR='/var/www/html'
 PROJECT_NAME='directus'
 PROJECT_DIR="$DIR/$PROJECT_NAME"
+# Leave empty for latest release or use specific
+# version number for release (e.g. '6.4.9')
+PROJECT_VERS=''
 
-# make directus directory
-sudo mkdir $PROJECT_DIR
+mkdir "$PROJECT_DIR"
 
-get_directus(){
-  if [ ! -d "$PROJECT_DIR/.git" ]; then
-    # can't git clone on a non-empty directory
-    git clone https://github.com/directus/directus.git $PROJECT_DIR
-    pushd $PROJECT_DIR
+get_directus() {
+  if [ ! -d "${PROJECT_DIR}/.git" ]; then
+    DOWNLOAD_CMD="wget -O ${PROJECT_NAME}.tar.gz https://api.github.com/repos/${PROJECT_NAME}/${PROJECT_NAME}/tarball"
+
+    if [ -n "$PROJECT_VERS" ]; then
+      DOWNLOAD_CMD="${DOWNLOAD_CMD}/${PROJECT_VERS}"
+    fi
+
+    # Don't double quote as it needs to execute the command stored within
+    $DOWNLOAD_CMD
+
+    tar -xf "${PROJECT_NAME}.tar.gz" -C "$PROJECT_DIR" --strip 1
+
+    pushd "$PROJECT_DIR"
       composer install
     popd
   fi
 }
 
 install_directus() {
-  DIRECTUS_CLI=$PROJECT_DIR/bin/directus
-  php $DIRECTUS_CLI install:config -h localhost -u root -p 123 -n directus
-  php $DIRECTUS_CLI install:database
-  php $DIRECTUS_CLI install:install -e admin@getdirectus.com -p password -t "Directus Demo"
+  DIRECTUS_CLI="${PROJECT_DIR}/bin/directus"
+  php "$DIRECTUS_CLI" install:config -h localhost -u root -p 123 -n directus
+  php "$DIRECTUS_CLI" install:database
+  php "$DIRECTUS_CLI" install:install -e admin@getdirectus.com -p password -t "Directus Demo"
 }
 
 apt-get update


### PR DESCRIPTION
Included are stylistic changes as well, mostly along the lines of double quoting variables.

Currently Composer will complain that you should not run it as root/super user and while testing not running it as root/super had no adverse affects, so to stay what is seemingly the best practice path we can edit the Vagrantfile to run the bootstrapping shell script as unprivileged (`privileged: false`) and add `sudo` in the shell script only where necessary (e.g. project directory creation, unpacking the release, and updating repositories).

Also, maybe the README should have a note that the user should clear the synced *html/* directory with each `vagrant destroy`? Not doing that will trip up the subsequent `vagrant up` since the directory doesn't automatically clear itself on the host OS.